### PR TITLE
chore/remove 3rd party

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,19 +1,3 @@
-[submodule "third_party/safe-contracts"]
-	path = third_party/safe-contracts
-	url = https://github.com/gnosis/safe-contracts
-	ignore = dirty
-[submodule "third_party/v2-periphery"]
-	path = third_party/v2-periphery
-	url = https://github.com/Uniswap/v2-periphery
-	ignore = dirty
-[submodule "third_party/v2-core"]
-	path = third_party/v2-core
-	url = https://github.com/Uniswap/v2-core
-	ignore = dirty
-[submodule "third_party/openzeppelin-contracts"]
-	path = third_party/openzeppelin-contracts
-	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-	ignore = dirty
 [submodule "third_party/contracts-elcol/third_party/canonical-weth"]
 	path = third_party/contracts-elcol/third_party/canonical-weth
 	url = https://github.com/gnosis/canonical-weth.git

--- a/packages/elcollectooorr/agents/elcollectooorr/tests/fixture_helpers.py
+++ b/packages/elcollectooorr/agents/elcollectooorr/tests/fixture_helpers.py
@@ -16,6 +16,7 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
+# pylint: skip-file
 # mypy: ignore-errors
 # flake8: noqa
 

--- a/packages/elcollectooorr/agents/elcollectooorr/tests/helpers/constants.py
+++ b/packages/elcollectooorr/agents/elcollectooorr/tests/helpers/constants.py
@@ -24,10 +24,9 @@ from typing import List, Tuple
 
 
 CUR_PATH = os.path.dirname(inspect.getfile(inspect.currentframe()))  # type: ignore
-ROOT_DIR = Path(CUR_PATH, "..", "..").resolve().absolute()
-TEST_DATA_DIR = ROOT_DIR / "tests" / "data"
-CONTRACTS_PACKAGES_DIR = ROOT_DIR / "packages" / "valory" / "contracts"
-ELCOL_CONTRACT_PACKAGES = ROOT_DIR / "packages" / "elcollectooorr" / "contracts"
+ROOT_DIR = Path(CUR_PATH, "..", "..", "..", "..",).resolve().absolute()
+TEST_DATA_DIR = ROOT_DIR / "agents" / "elcollectooorr" / "tests" / "data"
+ELCOL_CONTRACT_PACKAGES = ROOT_DIR / "contracts"
 DEFAULT_ASYNC_TIMEOUT = 5.0
 DEFAULT_REQUESTS_TIMEOUT = 5.0
 MAX_RETRIES = 30

--- a/packages/elcollectooorr/agents/elcollectooorr/tests/helpers/constants.py
+++ b/packages/elcollectooorr/agents/elcollectooorr/tests/helpers/constants.py
@@ -28,7 +28,6 @@ ROOT_DIR = Path(CUR_PATH, "..", "..").resolve().absolute()
 TEST_DATA_DIR = ROOT_DIR / "tests" / "data"
 CONTRACTS_PACKAGES_DIR = ROOT_DIR / "packages" / "valory" / "contracts"
 ELCOL_CONTRACT_PACKAGES = ROOT_DIR / "packages" / "elcollectooorr" / "contracts"
-THIRD_PARTY = ROOT_DIR / "third_party"
 DEFAULT_ASYNC_TIMEOUT = 5.0
 DEFAULT_REQUESTS_TIMEOUT = 5.0
 MAX_RETRIES = 30

--- a/packages/elcollectooorr/agents/elcollectooorr/tests/helpers/docker/elcol_net.py
+++ b/packages/elcollectooorr/agents/elcollectooorr/tests/helpers/docker/elcol_net.py
@@ -31,14 +31,9 @@ from aea.exceptions import enforce
 from aea_test_autonomy.docker.base import DockerImage
 from docker.models.containers import Container
 
-from packages.elcollectooorr.agents.elcollectooorr.tests.helpers.constants import (
-    THIRD_PARTY,
-)
-
 
 DEFAULT_HARDHAT_ADDR = "http://127.0.0.1"
 DEFAULT_HARDHAT_PORT = 8545
-ELCOL_CONTRACTS_ROOT_DIR = THIRD_PARTY / "contracts-elcol"
 
 _SLEEP_TIME = 1
 
@@ -59,6 +54,8 @@ ARTBLOCKS_SET_PRICE_V0_CONTRACT = "0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE"
 class ElColNetDockerImage(DockerImage):
     """Spawn a local network with deployed Gnosis Safe Factory, Fracionalize and Artblocks contracts."""
 
+    _CONTAINER_PORT = DEFAULT_HARDHAT_PORT
+
     def __init__(
         self,
         client: docker.DockerClient,
@@ -77,32 +74,15 @@ class ElColNetDockerImage(DockerImage):
     @property
     def tag(self) -> str:
         """Get the tag."""
-        return "node:16.7.0"
-
-    def _build_command(self) -> List[str]:
-        """Build command."""
-        cmd = ["run", "hardhat", "extra-compile", "--port", str(self.port)]
-        return cmd
+        return "valory/elcollectooorr-network:latest"
 
     def create(self) -> Container:
         """Create the container."""
-        cmd = self._build_command()
-        working_dir = "/build"
-        volumes = {
-            str(ELCOL_CONTRACTS_ROOT_DIR): {
-                "bind": working_dir,
-                "mode": "rw",
-            },
-        }
-        ports = {f"{self.port}/tcp": ("0.0.0.0", self.port)}  # nosec
+        ports = {f"{self._CONTAINER_PORT}/tcp": ("0.0.0.0", self.port)}  # nosec
         container = self._client.containers.run(
             self.tag,
-            command=cmd,
             detach=True,
             ports=ports,
-            volumes=volumes,
-            working_dir=working_dir,
-            entrypoint="yarn",
             extra_hosts={"host.docker.internal": "host-gateway"},
         )
         return container

--- a/packages/elcollectooorr/agents/elcollectooorr/tests/test_agents/test_elcollectooorr_abci.py
+++ b/packages/elcollectooorr/agents/elcollectooorr/tests/test_agents/test_elcollectooorr_abci.py
@@ -24,12 +24,15 @@
 
 import pytest
 
+from packages.elcollectooorr.agents.elcollectooorr.tests.fixture_helpers import (
+    UseHardHatElColBaseTest,
+)
 from packages.elcollectooorr.agents.elcollectooorr.tests.helpers.constants import (
     TARGET_PROJECT_ID as _DEFAULT_TARGET_PROJECT_ID,
 )
-
-from packages.elcollectooorr.agents.elcollectooorr.tests.fixture_helpers import UseHardHatElColBaseTest
-from packages.elcollectooorr.agents.elcollectooorr.tests.test_agents.base_elcollectooorr import BaseTestElCollectooorrEnd2End
+from packages.elcollectooorr.agents.elcollectooorr.tests.test_agents.base_elcollectooorr import (
+    BaseTestElCollectooorrEnd2End,
+)
 
 
 TARGET_PROJECT_ID = _DEFAULT_TARGET_PROJECT_ID

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -29,7 +29,7 @@
     "skill/valory/reset_pause_abci/0.1.0": "bafybeihywet5df7nrgarlx5qqkef6ofh6xrcd3hm2m7mpqpqfvbypra3wq",
     "skill/valory/safe_deployment_abci/0.1.0": "bafybeicjswvogpm3rut3aghokeodfm3ug2t74zy5og5xnpmid4cdfrazda",
     "skill/elcollectooorr/elcollectooorr_abci/0.1.0": "bafybeie4nmf6inuhpb3xg6pbjtaekpksylehon2okbgm575fnxfzbgdcbu",
-    "agent/elcollectooorr/elcollectooorr/0.1.0": "bafybeieprk5sslb4f5nzxqvopaeivfx422y6fi2nv64w7ci3jqpbyhzjmu",
+    "agent/elcollectooorr/elcollectooorr/0.1.0": "bafybeihr2tl6wce6gstxn2r6rvoyxihlwxrhhc4di47nsofapiiwaihf7m",
     "contract/elcollectooorr/token_settings/0.1.0": "bafybeif4kdwwk2u22eo34cwkjvg2eeh2rfpzjmkmkys4ns33fdqkhxhryi",
     "service/elcollectooorr/elcollectooorr/0.1.0": "bafybeidiqexiuvpmnw5zgfxbngnqbsslp3gmoq3wbe3qch4u2tsthh6tdy"
 }


### PR DESCRIPTION
The elcollectooorr network still remain under `third_party`. But the tests make use of the docker image.