### PR TITLE
feat: build images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,85 @@
+name: Release Flow
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-packages:
+    name: Push Packages
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10"]
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-versions }}
+      - uses: addnab/docker-run-action@v3
+        with:
+            image: valory/open-autonomy-user:latest
+            options: -v ${{ github.workspace }}:/work
+            run: |
+              echo "Pushing Packages"
+              cd /work
+              export AUTHOR=$(grep 'service' packages/packages.json | awk -F/ '{print $2}' | head -1)
+              autonomy init --reset --author $AUTHOR --ipfs --remote
+              autonomy push-all
+  publish-images:
+    name: Publish Docker Images
+    runs-on: ${{ matrix.os }}
+    needs:
+      - "publish-packages"
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10"]
+    env:
+        VERSION:  ${{github.event.release.tag_name}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up tag and vars
+        uses: addnab/docker-run-action@v3
+        with:
+            image: valory/open-autonomy-user:latest
+            options: -v ${{ github.workspace }}:/work
+            run: |
+              echo "Setting Tag Images"
+              cd /work
+              echo VERSION=$VERSION > env.sh
+              echo AUTHOR=$(grep 'service' packages/packages.json | awk -F/ '{print $2}' | head -1) >> env.sh
+              echo SERVICE=$(grep 'service' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
+              echo DEFAULT_IMAGE_TAG=$(cat packages/packages.json | grep agent | awk -F: '{print $2}' | tr -d '", ') >> env.sh
+              cat env.sh
+
+      - uses: addnab/docker-run-action@v3
+        name: Build Images
+        with:
+            image: valory/open-autonomy-user:latest
+            options: -v ${{ github.workspace }}:/work
+            shell: bash
+            run: |
+              echo "Building Docker Images"
+              cd /work
+              source env.sh || exit 1
+              echo "Building images for $AUTHOR for service $SERVICE"
+              autonomy fetch $AUTHOR/$SERVICE --service --local || exit 1
+              cd $SERVICE || exit 1
+              autonomy build-image || exit 1
+              autonomy build-image --version $VERSION || exit 1
+
+
+      - name: Docker login
+        env:
+          DOCKER_USER: ${{secrets.DOCKER_USER}}
+          DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+        run: |
+            echo  $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin 
+      - name: Docker Push
+        run: |
+          source env.sh
+          docker push $DOCKER_USER/oar-$SERVICE:$VERSION
+          docker push $DOCKER_USER/oar-$SERVICE:$DEFAULT_IMAGE_TAG
+


### PR DESCRIPTION
Adds in automatic image building
Well that was frustrating.

I present;

A generalised release flow.

Features -> automatice author and service detection
-> pushes packages
-> pushes images.
-> pushes both tagged images with the version which MUST BE SET IN THE WORKFLOW FOR NOW
and the image generated with the agent hash as default