### PR TITLE
Doc/make set up step explicit

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ The MintKit is a toolkit to build services with minting capabilities. For exampl
 
 In order to run a local demo of the El Collectooorr service:
 
-1. [Set up your system](https://docs.autonolas.network/open-autonomy/guides/set_up/) to work with the Open Autonomy. We recommend that you use these commands:
+1. [Set up your system](https://docs.autonolas.network/open-autonomy/guides/set_up/) to work with the Open Autonomy framework. We recommend that you use these commands:
 
     ```bash
     mkdir your_workspace && cd your_workspace

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,22 +7,32 @@ The MintKit is a toolkit to build services with minting capabilities. For exampl
 
 	This section is under active development - please report issues in the [Autonolas Discord](https://discord.com/invite/z2PT65jKqQ).
 
-Once you have {{set_up_system}} to work with the Open Autonomy framework, you can run a local demo of the El Collectooorr service as follows:
+In order to run a local demo of the El Collectooorr service:
 
-1. Fetch the El Collectooorr service.
+1. [Set up your system](https://docs.autonolas.network/open-autonomy/guides/set_up/) to work with the Open Autonomy. We recommend that you use these commands:
+
+    ```bash
+    mkdir your_workspace && cd your_workspace
+    touch Pipfile && pipenv --python 3.10 && pipenv shell
+
+    pipenv install open-autonomy[all]==0.9.0
+    autonomy init --remote --ipfs --reset --author=your_name
+    ```
+
+2. Fetch the El Collectooorr service.
 
 	```bash
 	autonomy fetch elcollectooorr/elcollectooorr:0.1.0:bafybeicvcajpylaooarzpcprm6spy46rgltdjqqvciuuse65hygz62s6yy --service
 	```
 
-2. Build the Docker image of the service agents
+3. Build the Docker image of the service agents
 
 	```bash
 	cd elcollectooorr
 	autonomy build-image
 	```
 
-3. Prepare the `keys.json` file containing the wallet address and the private key for each of the agents.
+4. Prepare the `keys.json` file containing the wallet address and the private key for each of the agents.
 
     ??? example "Example of a `keys.json` file"
 
@@ -49,7 +59,7 @@ Once you have {{set_up_system}} to work with the Open Autonomy framework, you ca
         ]
         ```
 
-4. Prepare the environment and build the service deployment.
+5. Prepare the environment and build the service deployment.
 
 	1. Create an `.env` file with the required environment variables.
 
@@ -72,7 +82,7 @@ Once you have {{set_up_system}} to work with the Open Autonomy framework, you ca
     autonomy deploy build keys.json --aev
     ```
 
-5. Run the service.
+6. Run the service.
 
 	```bash
 	cd abci_build


### PR DESCRIPTION
Make set up step explicit in the demo instructions so that it indicates the specific version of Open Autonomy that the service currently supports.

This is done in order to avoid situations where the Open Autonomy framework has been updated with a backwards-incompatible change (and thus the service cannot refer to the "normal" set up instructions).