### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,9 +78,9 @@ jobs:
               autonomy init --reset --author $AUTHOR --ipfs --remote
               autonomy fetch $AUTHOR/$SERVICE --service --local || exit 1
               cd $SERVICE || exit 1
-              autonomy build-image || exit 1
-              autonomy build-image --version $VERSION || exit 1
-
+              autonomy build-image --image-author $DOCKER_USER || exit 1
+              docker tag $DOCKER_USER/oar-$SERVICE:$DEFAULT_IMAGE_TAG $DOCKER_USER/oar-$SERVICE:$VERSION || exit 1
+              docker tag $DOCKER_USER/oar-$SERVICE:$DEFAULT_IMAGE_TAG $DOCKER_USER/oar-$SERVICE:latest || exit 1
 
       - name: Docker login
         run: |
@@ -88,8 +88,9 @@ jobs:
       - name: Docker Push
         run: |
           source env.sh
-          echo "Pushing $DOCKER_USER/$SERVICE:$VERSION"
-          echo "Pushing $DOCKER_USER/$SERVICE:$DEFAULT_IMAGE_TAG"
-          docker push $DOCKER_USER/oar-$SERVICE:$VERSION
-          docker push $DOCKER_USER/oar-$SERVICE:$DEFAULT_IMAGE_TAG
-
+          for TAG in $VERSION $DEFAULT_IMAGE_TAG latest
+          do
+              IMAGE_NAME="$DOCKER_USER/oar-$SERVICE:$TAG"
+              echo "Pushing $IMAGE_NAME"
+              docker push $IMAGE_NAME
+          done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
                   echo "You are not on a tagged branch"
                   exit 1
               fi
-              echo VERSION=$TAG> env.sh
+              echo VERSION=$TAG > env.sh
               echo AUTHOR=$(grep 'service' packages/packages.json | awk -F/ '{print $2}' | head -1) >> env.sh
               echo SERVICE=$(grep 'service' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
               echo AGENT=$(grep 'agent' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
@@ -66,29 +66,30 @@ jobs:
               cat env.sh
 
       - uses: addnab/docker-run-action@v3
-        name: Build Images
+        name: Build Agent Image
         with:
             image: valory/open-autonomy-user:latest
             options: -v ${{ github.workspace }}:/work
             shell: bash
             run: |
-              echo "Building Docker Images"
+              echo "Building Docker Agent Image"
               cd /work
               source env.sh || exit 1
-              echo "Building images for $AUTHOR for service $SERVICE"
+              echo "Building image for $AUTHOR for service $SERVICE"
               autonomy init --reset --author $AUTHOR --ipfs --remote
               autonomy fetch $AUTHOR/$SERVICE --service --local || exit 1
               cd $SERVICE || exit 1
               autonomy build-image --image-author $DOCKER_USER || exit 1
-              docker tag $DOCKER_USER/oar-$AGENT:$DEFAULT_IMAGE_TAG $DOCKER_USER/oar-$AGENT:$VERSION || exit 1
-              docker tag $DOCKER_USER/oar-$AGENT:$DEFAULT_IMAGE_TAG $DOCKER_USER/oar-$AGENT:latest || exit 1
 
       - name: Docker login
         run: |
             echo  $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin
-      - name: Docker Push
+
+      - name: Docker Tag and Push
         run: |
           source env.sh
+          docker tag $DOCKER_USER/oar-$AGENT:$DEFAULT_IMAGE_TAG $DOCKER_USER/oar-$AGENT:latest || exit 1
+          docker tag $DOCKER_USER/oar-$AGENT:$DEFAULT_IMAGE_TAG $DOCKER_USER/oar-$AGENT:$VERSION || exit 1
           for TAG in $VERSION $DEFAULT_IMAGE_TAG latest
           do
               IMAGE_NAME="$DOCKER_USER/oar-$AGENT:$TAG"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,6 +61,7 @@ jobs:
               echo VERSION=$TAG> env.sh
               echo AUTHOR=$(grep 'service' packages/packages.json | awk -F/ '{print $2}' | head -1) >> env.sh
               echo SERVICE=$(grep 'service' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
+              echo AGENT=$(grep 'agent' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
               echo DEFAULT_IMAGE_TAG=$(cat packages/packages.json | grep agent | awk -F: '{print $2}' | tr -d '", ') >> env.sh
               cat env.sh
 
@@ -79,8 +80,8 @@ jobs:
               autonomy fetch $AUTHOR/$SERVICE --service --local || exit 1
               cd $SERVICE || exit 1
               autonomy build-image --image-author $DOCKER_USER || exit 1
-              docker tag $DOCKER_USER/oar-$SERVICE:$DEFAULT_IMAGE_TAG $DOCKER_USER/oar-$SERVICE:$VERSION || exit 1
-              docker tag $DOCKER_USER/oar-$SERVICE:$DEFAULT_IMAGE_TAG $DOCKER_USER/oar-$SERVICE:latest || exit 1
+              docker tag $DOCKER_USER/oar-$AGENT:$DEFAULT_IMAGE_TAG $DOCKER_USER/oar-$AGENT:$VERSION || exit 1
+              docker tag $DOCKER_USER/oar-$AGENT:$DEFAULT_IMAGE_TAG $DOCKER_USER/oar-$AGENT:latest || exit 1
 
       - name: Docker login
         run: |
@@ -90,7 +91,7 @@ jobs:
           source env.sh
           for TAG in $VERSION $DEFAULT_IMAGE_TAG latest
           do
-              IMAGE_NAME="$DOCKER_USER/oar-$SERVICE:$TAG"
+              IMAGE_NAME="$DOCKER_USER/oar-$AGENT:$TAG"
               echo "Pushing $IMAGE_NAME"
               docker push $IMAGE_NAME
           done


### PR DESCRIPTION
## Description
Uses the docker user as an image author and also tags with `latest`.

## More information
This PR fixes an issue with the release workflow and also tags with `latest` which was missing.

#### Issue
Previously, we were using the default image author, which is the IPFS author, which is initialized using the author of the service package, i.e., `elcollectooorr`. The release workflow was failing because we were instead trying to push the image using the docker user as an image author.

#### Resolution
By introducing this change, we now use the docker user as the image author when building the image.

#### Suggestion
Please note that we might want to consider keeping the old approach when building the image, i.e., using the package author as the image author. In this case, we would push using this image name instead of the docker user. This might be the best approach as the image's name would contain the author of the package.

However, if we were to keep the current PR's approach it might also make more sense to rename the `elcollectooorr` author of the packages.